### PR TITLE
Fix markdown inline code highlight

### DIFF
--- a/blog.araya.dev/styles/markdown.css
+++ b/blog.araya.dev/styles/markdown.css
@@ -64,6 +64,7 @@
   max-width: 100%;
   overflow-x: scroll;
   margin: 0 0.2em;
+  color: var(--gray-light-3);
 }
 
 .markdown pre code {


### PR DESCRIPTION
In light mode, inline code fragments are filled with black as below.
![image](https://user-images.githubusercontent.com/14837380/93198543-1fd6b880-f788-11ea-8d94-b1f7e81836f3.png)


This change attaches `gray-light-3` as the same color with dark mode text face color.

It seems the css is different from actual website css, which is my concern.
Actual css has `background-color` and `padding` in addition to my edited css.
Should I update the css file to be the same as actual one?

## Result

|light mode|dark mode|
|--|--|
|![image](https://user-images.githubusercontent.com/14837380/93199126-ece0f480-f788-11ea-900a-defc579cf390.png)|![image](https://user-images.githubusercontent.com/14837380/93199167-fec29780-f788-11ea-9dc8-83795c77dc39.png)|
