### PR TITLE
fe2o3 is dead

### DIFF
--- a/blog.araya.dev/src/posts/2017-12-02-f-to-h.md
+++ b/blog.araya.dev/src/posts/2017-12-02-f-to-h.md
@@ -17,7 +17,7 @@ tags:
 <blockquote class="twitter-tweet" data-lang="ja"><p lang="ja" dir="ltr">フラー株式会社での最終出勤日を終えました。<br>退職エントリーは後ほど <a href="https://t.co/Y5C6slYICS">pic.twitter.com/Y5C6slYICS</a></p>&mdash; あらや (@_araya_) <a href="https://twitter.com/_araya_/status/908626234342465537?ref_src=twsrc%5Etfw">2017年9月15日</a></blockquote>
 <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 
-翌日、10月1日に[合同会社ヘマタイト](https://fe2o3.jp)に入社し、現在楽しく働いています。
+翌日、10月1日に[合同会社ヘマタイト](https://web.archive.org/web/20210127134531/https://fe2o3.jp/)に入社し、現在楽しく働いています。
 
 退職エントリを書き途中で長らく放置していたのですが、
 ちょうど退職者Advent Calendarが目に留まりこれは良いと思って即参加登録しました。


### PR DESCRIPTION
As you known, [hematitecorp is dead](https://www.facebook.com/hematitecorp/posts/930446390694276).
Since hematitecorp has given away the fe2o3\.jp domain, someone might abuse it.
We should not link to this domain.