### PR TITLE
Pin GitHub Actions to specific commits and switch pnpm setup to Corepack

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -13,12 +13,9 @@ jobs:
       SSH_USER: ubuntu
       REMOTE_ROOT: /var/www/araya.dev
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10.15.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node.js env
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -28,6 +25,8 @@ jobs:
       - name: Build blog
         working-directory: ./blog.araya.dev
         run: |
+          corepack enable
+          corepack prepare pnpm@10.15.1 --activate
           pnpm install --frozen-lockfile
           pnpm build:prod
       - name: Setup SSH keys


### PR DESCRIPTION
### Motivation
- Ensure CI reproducibility by pinning `actions/checkout` and `actions/setup-node` to exact commits, and replace the `pnpm/action-setup` step with `corepack` to manage the `pnpm` version consistently.

### Description
- Replace `uses: actions/checkout@v4` with a commit-pinned reference `actions/checkout@de0fac2e...` (v6.0.2).
- Replace `uses: actions/setup-node@v4` with a commit-pinned reference `actions/setup-node@53b8394...` (v6.3.0) while keeping `node-version-file` and pnpm cache settings.
- Remove the `pnpm/action-setup@v4` step and add `corepack enable` and `corepack prepare pnpm@10.15.1 --activate` before running `pnpm install` and `pnpm build:prod` in the `Build blog` step.
- Preserve deployment steps, SSH setup, and the `rsync` deploy command targeting `REMOTE_ROOT` on the remote server.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e454cb7bfc832291b74d368afb4444)